### PR TITLE
Fix question text output

### DIFF
--- a/parse_midterms.py
+++ b/parse_midterms.py
@@ -28,7 +28,7 @@ for TEST in TESTS:
 	URL = BASE_DIR + TEST
 
 	txt = urllib.request.urlopen(URL).read()
-	txt = str(txt)
+	txt = txt.decode("ISO-8859-1")
 
 	free_response = txt.split("Multiple choice")[0]
 	multiple_choice = txt.split("Multiple choice")[1:]
@@ -58,7 +58,7 @@ for TEST in TESTS:
 			continue	
 		if(num_matched/num_tot > accuracy):
 			# print(num_matched, num_tot)
-			output.write("Question " +str(index) + " on Free Response on " + TEST +" with accuracy " + str(num_matched/num_tot) + ": " + '\n' + " ".join(temp)+'\n\n\n')
+			output.write("Question " +str(index) + " on Free Response on " + TEST +" with accuracy " + str(num_matched/num_tot) + ": " + '\n' + "".join(elem)+'\n\n\n')
 		index+=1
 	index=1
 	for elem in mc:
@@ -75,6 +75,6 @@ for TEST in TESTS:
 			index+=1
 			continue
 		if(num_matched/num_tot > accuracy):
-			output.write("Question " +str(index) + " on Multiple Choice on " + TEST	 +" with accuracy " + str(num_matched/num_tot) +": " +'\n' + " ".join(temp)+'\n\n\n')
+			output.write("Question " +str(index) + " on Multiple Choice on " + TEST	 +" with accuracy " + str(num_matched/num_tot) +": " +'\n' + "".join(elem)+'\n\n\n')
 		index+=1
 output.close()


### PR DESCRIPTION
The original files are encoded in ISO-8859 and are retrieved as literal
bytestreams, but as a result, trying to construct strings out of them
results in the repr version of the bytestrings. Calling the decode()
function instead fixes that.

In addition, the whitespace-split version of the question text is being
written to the output file, but as a result, all newlines are
obliterated. Write the not-whitespace-split version of the question text
to the file instead.